### PR TITLE
fix: override noEmit to emit types, needed when used alongside create…

### DIFF
--- a/src/helpers/compileTypes.ts
+++ b/src/helpers/compileTypes.ts
@@ -34,6 +34,7 @@ export function compileTypes(exposedComponents: string[], outFile: string, dirGl
   Object.assign(compilerOptions, {
     declaration: true,
     emitDeclarationOnly: true,
+    noEmit: false,
     outFile,
   } as ts.CompilerOptions);
 


### PR DESCRIPTION
…-react-app

https://github.com/facebook/create-react-app/blob/9802941ff049a28da2682801bc182a29761b71f4/packages/react-scripts/config/webpack.config.js#L734