### PR TITLE
Add support for specifying the module federation plugin name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Requirements:
   "name": "microapp-42",
   "exposes": {
     "./Button": "./src/view-layer/components/Button",
-    "./Portal": "./src/view-layer/index"
+    "./Portal": "./src/view-layer/index",
     "./Http": "./src/wmf-expose/Http"
   }
 }
@@ -146,6 +146,7 @@ To enable verbose logging add folowing in webpack config:
 |                        `remoteEntryUrls` |  `RemoteEntryUrls`   |         `{}`         | Base URLs for types. These should target compiled bundles that also contain the types. E.g. with `{ mfeApp: 'https://assets.mydomain.com/mfe-app' }` the types will be downloaded from `'https://assets.mydomain.com/mfe-app/@types/index.d.ts'`. More details available in [this section](#templated-remote-urls)                       |
 |                     `remoteManifestUrls` | `RemoteManifestUrls` |         `{}`         | URLs to remote manifest files. A manifest contains a URL to a remote entry that is substituted in runtime.  <br><br> More details available in [this section](#templated-remote-urls)                                                                                                                                                    |
 |        `cloudbedsRemoteManifestsBaseUrl` |       `string`       | `'/remotes/dev-ga'`  | Base URL for remote `remote-entries.json` manifest file that is specific to Cloudbeds microapps <br><br> _Examples:_ <br> `http://localhost:4480/remotes/dev` (or `/dev-docker`) <br> `https://cb-front.cloudbeds-dev.com/remotes/[env]`. <br><br> `remoteManifestUrls` is ignored when this setting has a value other than `undefined`. |
+|                         `mfPluginName`   |       `string`       |       `ModuleFederationPlugin`       | The name of the module federation plugin.  Change this to "NextFederationPlugin" if you are using this plugin with @module-federation/nextjs-mf |
 
 
 ## Consuming remote types

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -24,6 +24,8 @@ import {
 let isCompiledOnce = false;
 let isDownloadedOnce = false;
 
+const DEFAULT_MODULE_FEDERATION_PLUGIN_NAME = 'ModuleFederationPlugin';
+
 export class ModuleFederationTypesPlugin implements WebpackPluginInstance {
   constructor(public options?: ModuleFederationTypesPluginOptions) {}
 
@@ -55,9 +57,12 @@ export class ModuleFederationTypesPlugin implements WebpackPluginInstance {
       return;
     }
 
+    // Allow for other module federation plugins such as this "NextFederationPlugin"
+    const mfPluginName = this.options?.mfPluginName ?? DEFAULT_MODULE_FEDERATION_PLUGIN_NAME;
+
     // Get ModuleFederationPlugin config
     const federationOptions = compiler.options.plugins.find((plugin) => {
-      return plugin!.constructor.name === 'ModuleFederationPlugin';
+      return plugin!.constructor.name === mfPluginName;
     });
     const federationPluginOptions: ModuleFederationPluginOptions = (federationOptions as any)?._options;
     if (!federationPluginOptions?.name) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export type ModuleFederationTypesPluginOptions = {
   remoteEntryUrls?: RemoteEntryUrls,
   remoteManifestUrls?: RemoteManifestUrls,
   remoteManifestUrl?: string,
+  mfPluginName?: string
 
   cloudbedsRemoteManifestsBaseUrl?: string | ''
     | 'dev' | 'dev-ga'


### PR DESCRIPTION
This allows this plugin to work with the @module-federation/nextjs-mf plugin (or others)