### PR TITLE
fix: alias replace in internal imported declares

### DIFF
--- a/src/downloadTypes/helpers/downloadRemoteEntryTypes.ts
+++ b/src/downloadTypes/helpers/downloadRemoteEntryTypes.ts
@@ -28,8 +28,8 @@ export async function downloadRemoteEntryTypes(
   // with a name (an alias) that is used in `remotes` object. Usually these are same.
   if (remoteName !== remoteOriginalName) {
     types = types.replace(
-      new RegExp(`declare module "${remoteOriginalName}(.*)"`, 'g'),
-      (_, $1) => `declare module "${remoteName}${$1}"`,
+      new RegExp(`"${remoteOriginalName}(.*)"`, 'g'),
+      (_, $1) => `"${remoteName}${$1}"`,
     );
   }
 


### PR DESCRIPTION
Currently the plugin replace `remoteOriginalName` with `remoteName` for declare modules only, and misses the internal import inside the module

example: we expose `/types`: './src/types/index' from a micro frontend, and we expose a component that uses a type from the exposed types, but because we only replace `remoteOriginalName`  with `remoteName` in the declare module, it didn't replace it inside the component type declare


<img width="500" alt="image" src="https://github.com/cloudbeds/webpack-module-federation-types-plugin/assets/72743038/6bb30010-3360-4c33-8c62-4b2451196a55">

<img width="582" alt="image" src="https://github.com/cloudbeds/webpack-module-federation-types-plugin/assets/72743038/625c4004-7ee2-4543-a57d-c61dabba9365">


after fix: 

<img width="510" alt="image" src="https://github.com/cloudbeds/webpack-module-federation-types-plugin/assets/72743038/505ca374-2c59-4d1e-8322-b028c2f36b6b">

