### PR TITLE
feat: substitute aliased modules

### DIFF
--- a/src/compileTypes/helpers/__tests__/includeTypesFromNodeModules.test.ts
+++ b/src/compileTypes/helpers/__tests__/includeTypesFromNodeModules.test.ts
@@ -1,0 +1,58 @@
+import { FederationConfig } from '../../../models';
+import { setLogger } from '../../../helpers';
+import { includeTypesFromNodeModules } from '../includeTypesFromNodeModules';
+
+// Assuming logger mock setup is similar to previous example
+const mockLogger = {
+  log: jest.fn(),
+  warn: jest.fn(),
+};
+
+setLogger(mockLogger);
+
+describe('includeTypesFromNodeModules', () => {
+  test('correctly includes typings for exposed NPM packages', () => {
+    const federationConfig: FederationConfig = {
+      name: 'myApp',
+      exposes: {
+        ModuleA: './node_modules/libraryA',
+        ModuleB: './node_modules/libraryB',
+      },
+    };
+    const initialTypings = 'initial typings content';
+
+    const result = includeTypesFromNodeModules(federationConfig, initialTypings);
+
+    const moduleADeclaration = [
+      'declare module "myApp/ModuleA" {',
+      '  export * from "libraryA"',
+      '}',
+    ].join('\n');
+    const moduleBDeclaration = [
+      'declare module "myApp/ModuleB" {',
+      '  export * from "libraryB"',
+      '}',
+    ].join('\n');
+
+    expect(result).toBe([initialTypings, moduleADeclaration, moduleBDeclaration].join('\n'));
+    expect(mockLogger.log).toHaveBeenCalledWith('Including typings for npm packages:', [
+      ['ModuleA', 'libraryA'],
+      ['ModuleB', 'libraryB'],
+    ]);
+  });
+
+  test('does not modify typings when there are no NPM package paths', () => {
+    const federationConfig: FederationConfig = {
+      name: 'myApp',
+      exposes: {
+        LocalModule: './src/LocalModule',
+      },
+    };
+    const initialTypings = 'initial typings content';
+
+    const result = includeTypesFromNodeModules(federationConfig, initialTypings);
+
+    expect(result).toBe(initialTypings);
+    expect(mockLogger.log).not.toHaveBeenCalledWith();
+  });
+});

--- a/src/compileTypes/helpers/__tests__/substituteAliasedModules.test.ts
+++ b/src/compileTypes/helpers/__tests__/substituteAliasedModules.test.ts
@@ -1,0 +1,41 @@
+import { substituteAliasedModules } from '../substituteAliasedModules';
+import {
+  getLogger, setLogger,
+} from '../../../helpers';
+import { PREFIX_NOT_FOR_IMPORT } from '../../../constants';
+
+const mockLogger = {
+  log: jest.fn(),
+};
+
+setLogger(mockLogger);
+
+describe('substituteAliasedModules', () => {
+  const federatedModuleName = 'myCommon';
+  const logger = getLogger();
+
+  test('substitutes import path when #not-for-import version exists', () => {
+    const modulePath = 'libs/currency';
+    const typings = `
+      Some import("${modulePath}") more content
+      declare module "${PREFIX_NOT_FOR_IMPORT}/${federatedModuleName}/${modulePath}"
+    `;
+
+    const subsituted = substituteAliasedModules(federatedModuleName, typings);
+
+    expect(subsituted).toBe(`
+      Some import("${PREFIX_NOT_FOR_IMPORT}/${federatedModuleName}/${modulePath}") more content
+      declare module "${PREFIX_NOT_FOR_IMPORT}/${federatedModuleName}/${modulePath}"
+    `);
+    expect(logger.log).toHaveBeenCalledWith(`Substituting import path: ${modulePath}`);
+  });
+
+  test('does not modify typings when a #not-for-import version does not exist', () => {
+    const originalTypings = 'Some content import("another/module") more content';
+
+    const result = substituteAliasedModules(federatedModuleName, originalTypings);
+
+    expect(result).toBe(originalTypings);
+    expect(logger.log).not.toHaveBeenCalled();
+  });
+});

--- a/src/compileTypes/helpers/includeTypesFromNodeModules.ts
+++ b/src/compileTypes/helpers/includeTypesFromNodeModules.ts
@@ -15,12 +15,11 @@ export function includeTypesFromNodeModules(federationConfig: FederationConfig, 
       exposeTargetPath.replace('./node_modules/', ''),
     ]);
 
-  // language=TypeScript
-  const createNpmModule = (exposedModuleKey: string, packageName: string) => `
-    declare module "${federationConfig.name}/${exposedModuleKey}" {
-      export * from "${packageName}"
-    }
-  `;
+  const createNpmModule = (exposedModuleKey: string, packageName: string) => [
+    `declare module "${federationConfig.name}/${exposedModuleKey}" {`,
+    `  export * from "${packageName}"`,
+    '}',
+  ].join('\n');
 
   if (exposedNpmPackages.length) {
     logger.log('Including typings for npm packages:', exposedNpmPackages);

--- a/src/compileTypes/helpers/index.ts
+++ b/src/compileTypes/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './getTSConfigCompilerOptions';
 export * from './includeTypesFromNodeModules';
 export * from './reportCompileDiagnostic';
+export * from './substituteAliasedModules';

--- a/src/compileTypes/helpers/substituteAliasedModules.ts
+++ b/src/compileTypes/helpers/substituteAliasedModules.ts
@@ -1,0 +1,31 @@
+import { getLogger } from '../../helpers';
+import { PREFIX_NOT_FOR_IMPORT } from '../../constants';
+
+export function substituteAliasedModules(federatedModuleName: string, typings: string): string {
+  const logger = getLogger();
+
+  // Collect all instances of `import("...")`
+  const regexImportPaths = /import\("([^"]*)"\)/g;
+  const uniqueImportPaths = new Set();
+
+  let match = regexImportPaths.exec(typings);
+  while (match) {
+    uniqueImportPaths.add(match[1]);
+    match = regexImportPaths.exec(typings);
+  }
+
+  uniqueImportPaths.forEach(importPath => {
+    const notForImportPath = `${PREFIX_NOT_FOR_IMPORT}/${federatedModuleName}/${importPath}`;
+
+    if (typings.includes(`declare module "${notForImportPath}"`)) {
+      logger.log(`Substituting import path: ${importPath}`);
+
+      typings = typings.replace(
+        new RegExp(`import\\("${importPath}"\\)`, 'g'),
+        `import("${notForImportPath}")`,
+      );
+    }
+  });
+
+  return typings;
+}

--- a/src/compileTypes/rewritePathsWithExposedFederatedModules.ts
+++ b/src/compileTypes/rewritePathsWithExposedFederatedModules.ts
@@ -4,8 +4,11 @@ import fs from 'fs';
 import mkdirp from 'mkdirp';
 
 import { FederationConfig } from '../models';
+import { PREFIX_NOT_FOR_IMPORT } from '../constants';
 
-import { includeTypesFromNodeModules } from './helpers';
+import {
+  includeTypesFromNodeModules, substituteAliasedModules,
+} from './helpers';
 
 export function rewritePathsWithExposedFederatedModules(
   federationConfig: FederationConfig,
@@ -38,7 +41,7 @@ export function rewritePathsWithExposedFederatedModules(
 
     let federatedModulePath = exposedModuleKey
       ? `${federationConfig.name}/${exposedModuleKey}`
-      : `#not-for-import/${federationConfig.name}/${importPath}`;
+      : `${PREFIX_NOT_FOR_IMPORT}/${federationConfig.name}/${importPath}`;
 
     federatedModulePath = federatedModulePath.replace(/\/index$/, '');
 
@@ -55,6 +58,7 @@ export function rewritePathsWithExposedFederatedModules(
     ].join('\n');
   });
 
+  typingsUpdated = substituteAliasedModules(federationConfig.name, typingsUpdated);
   typingsUpdated = includeTypesFromNodeModules(federationConfig, typingsUpdated);
 
   mkdirp.sync(path.dirname(outFile));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,3 +8,5 @@ export const DEFAULT_DIR_GLOBAL_TYPES = 'src/@types';
 export const DEFAULT_DIR_DOWNLOADED_TYPES = 'src/@types/remotes';
 
 export const DEFAULT_DOWNLOAD_TYPES_INTERVAL_IN_SECONDS = 60;
+
+export const PREFIX_NOT_FOR_IMPORT = '#not-for-import';


### PR DESCRIPTION
We have an issue with nested import resolution when typings are generated

![image](https://github.com/cloudbeds/webpack-module-federation-types-plugin/assets/3078595/2748d576-afed-48eb-80aa-94ae837fbeab)

that results in `any` type since TS cannot find module "contracts/types" in the consuming MFE

![image](https://github.com/cloudbeds/webpack-module-federation-types-plugin/assets/3078595/ae26b959-4488-4cd2-9f59-c75867f269d2)


As a solution, we'll replace all `import()` paths with existing ones from the exposed federated module

**Result**

![image](https://github.com/cloudbeds/webpack-module-federation-types-plugin/assets/3078595/959651c5-7247-4da6-90c3-3ef005862ba5)

![image](https://github.com/cloudbeds/webpack-module-federation-types-plugin/assets/3078595/8488c242-888d-43a3-b3ad-bc5cef8f5889)

![image](https://github.com/cloudbeds/webpack-module-federation-types-plugin/assets/3078595/eb0aca32-5456-4cd0-aad3-c4c86521ed75)

---

Also removed excessive empty space for node_modules

![image](https://github.com/cloudbeds/webpack-module-federation-types-plugin/assets/3078595/fc6eb295-407b-4bd5-a473-e9e6c0c87064)
