### PR TITLE
chore: parse tsconfig.json with built-in ts helper

### DIFF
--- a/src/compileTypes/helpers/getTSConfigCompilerOptions.ts
+++ b/src/compileTypes/helpers/getTSConfigCompilerOptions.ts
@@ -13,5 +13,12 @@ export function getTSConfigCompilerOptions(tsconfigFileNameOrPath: string): ts.C
     process.exit(1);
   }
 
-  return require(tsconfigPath).compilerOptions;
+  const tsconfigJsonFile = ts.readJsonConfigFile(tsconfigPath, ts.sys.readFile);
+  const parsedConfig = ts.parseJsonSourceFileConfigFileContent(
+    tsconfigJsonFile,
+    ts.sys,
+    path.dirname(tsconfigPath),
+  );
+
+  return parsedConfig.options;
 }


### PR DESCRIPTION
We use the plugin for our microfrontends setup and I wanted to upgrade to latest TypeScript 5.5.2 version, but was getting this error on `build` command:
```
Error: target is a string value; tsconfig JSON must be parsed with parseJsonSourceFileConfigFileContent or getParsedCommandLineOfConfigFile before passing to createProgram
    at Object.createProgram (.../mf/node_modules/typescript/lib/typescript.js:123997:15)
    at compileTypes (/mf/node_modules/@company/microfronts-utils/node_modules/@cloudbeds/webpack-module-federation-types-plugin/dist/compileTypes/compileTypes.js:37:42)
    at compileTypesAfterEmit (/mf/node_modules/@company/microfronts-utils/node_modules/@cloudbeds/webpack-module-federation-types-plugin/dist/plugin.js:68:84)
```

This PR provides a fix for mentioned issue 🙂