### PR TITLE
feat(plugin): support object-based MF2 exposed modules in ModuleFeder…

### DIFF
--- a/src/bin/make-federated-types.ts
+++ b/src/bin/make-federated-types.ts
@@ -46,14 +46,14 @@ if (argv['federation-config']) {
     .mfPluginOptions as FederationConfig;
 }
 
-const exposedModules = Object.values(federationConfig.exposes);
+const exposedModules = federationConfig.exposes;
 const outDir =
   argv['output-types-folder'] || path.join(DEFAULT_DIR_DIST, DEFAULT_DIR_EMITTED_TYPES);
 const outFile = path.join(outDir, 'index.d.ts');
 const dirGlobalTypes = argv['global-types'] || DEFAULT_DIR_GLOBAL_TYPES;
 const tsconfigPath = argv.tsconfig || TS_CONFIG_FILE;
 
-console.log(`Emitting types for ${exposedModules.length} exposed module(s)`);
+console.log(`Emitting types for ${Object.keys(exposedModules).length} exposed module(s)`);
 
 setLogger(console);
 

--- a/src/compileTypes/__tests__/compileTypesWorker.test.ts
+++ b/src/compileTypes/__tests__/compileTypesWorker.test.ts
@@ -59,7 +59,10 @@ describe('compileTypesWorker', () => {
   test('handles successful compilation and rewrite', () => {
     const workerMessage: CompileTypesWorkerMessage = {
       tsconfigPath: 'tsconfig.json',
-      exposedModules: ['moduleA', 'moduleB'],
+      exposedModules: {
+        './moduleA': 'moduleA',
+        './moduleB': 'moduleB',
+      },
       outFile: 'dist/types.d.ts',
       dirGlobalTypes: 'src/@types',
       federationConfig: {} as FederationConfig,
@@ -72,7 +75,10 @@ describe('compileTypesWorker', () => {
     expect(mockCompileTypes).toHaveBeenCalledWith(
       expect.objectContaining({
         tsconfigPath: 'tsconfig.json',
-        exposedModules: ['moduleA', 'moduleB'],
+        exposedModules: {
+          './moduleA': 'moduleA',
+          './moduleB': 'moduleB',
+        },
         outFile: 'dist/types.d.ts',
         dirGlobalTypes: 'src/@types',
       }),
@@ -92,7 +98,7 @@ describe('compileTypesWorker', () => {
   test('handles compilation failure', () => {
     const workerMessage: CompileTypesWorkerMessage = {
       tsconfigPath: 'tsconfig.json',
-      exposedModules: ['moduleA'],
+      exposedModules: { './moduleA': 'moduleA' },
       outFile: 'dist/types.d.ts',
       dirGlobalTypes: 'src/@types',
       federationConfig: {} as FederationConfig,
@@ -108,7 +114,7 @@ describe('compileTypesWorker', () => {
   test('handles errors during compilation', () => {
     const workerMessage: CompileTypesWorkerMessage = {
       tsconfigPath: 'tsconfig.json',
-      exposedModules: ['moduleA'],
+      exposedModules: { './moduleA': 'moduleA' },
       outFile: 'dist/types.d.ts',
       dirGlobalTypes: 'src/@types',
       federationConfig: {} as FederationConfig,
@@ -130,7 +136,7 @@ describe('compileTypesWorker', () => {
   test('logs performance metrics', () => {
     const workerMessage: CompileTypesWorkerMessage = {
       tsconfigPath: 'tsconfig.json',
-      exposedModules: ['moduleA'],
+      exposedModules: { './moduleA': 'moduleA' },
       outFile: 'dist/types.d.ts',
       dirGlobalTypes: 'src/@types',
       federationConfig: {} as FederationConfig,

--- a/src/compileTypes/compileTypes.ts
+++ b/src/compileTypes/compileTypes.ts
@@ -9,7 +9,7 @@ import { getTSConfigCompilerOptions, reportCompileDiagnostic } from './helpers';
 
 export type CompileTypesParams = {
   tsconfigPath: string;
-  exposedModules: string[];
+  exposedModules: Dict<string>;
   outFile: string;
   dirGlobalTypes: string;
 };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -82,6 +82,19 @@ export class ModuleFederationTypesPlugin implements WebpackPluginInstance {
       return;
     }
 
+    // In MF2 an item can be an object with `import` and `name` properties
+    federationPluginOptions.exposes = Object.entries(federationPluginOptions.exposes || {}).reduce(
+      (acc, [key, value]) => {
+        if (value && typeof value === 'object' && 'import' in value) {
+          acc[key] = (value as Dict<string>).import[0];
+        } else {
+          acc[key] = value;
+        }
+        return acc;
+      },
+      {} as Dict<string>,
+    );
+
     // Define path for the emitted typings file
     const { exposes, remotes } = federationPluginOptions;
 
@@ -100,7 +113,7 @@ export class ModuleFederationTypesPlugin implements WebpackPluginInstance {
         await compileTypesAsync(
           {
             tsconfigPath: TS_CONFIG_FILE,
-            exposedModules: exposes as string[],
+            exposedModules: exposes as Dict<string>,
             outFile,
             dirGlobalTypes,
             federationConfig: federationPluginOptions as FederationConfig,


### PR DESCRIPTION
This pull request includes several changes to the `compileTypesWorker` tests and the `ModuleFederationTypesPlugin` to handle exposed modules as objects rather than arrays. The most important changes include updating the test cases and modifying the `exposes` handling logic in the plugin.

Updates to test cases:

* [`src/compileTypes/__tests__/compileTypesWorker.test.ts`](diffhunk://#diff-47326d4319c8d42356b38351f6c6103f576fa8abb8aa675e900cadeff53c3accL62-R65): Changed `exposedModules` from an array to an object in multiple test cases to reflect the new structure. [[1]](diffhunk://#diff-47326d4319c8d42356b38351f6c6103f576fa8abb8aa675e900cadeff53c3accL62-R65) [[2]](diffhunk://#diff-47326d4319c8d42356b38351f6c6103f576fa8abb8aa675e900cadeff53c3accL75-R81) [[3]](diffhunk://#diff-47326d4319c8d42356b38351f6c6103f576fa8abb8aa675e900cadeff53c3accL95-R101) [[4]](diffhunk://#diff-47326d4319c8d42356b38351f6c6103f576fa8abb8aa675e900cadeff53c3accL111-R117) [[5]](diffhunk://#diff-47326d4319c8d42356b38351f6c6103f576fa8abb8aa675e900cadeff53c3accL133-R139)

Plugin modifications:

* [`src/compileTypes/compileTypes.ts`](diffhunk://#diff-ac29c601a5562c237b628d6e1dd09512fcb7df01f0fe4b195c398ff3d55f3a0fL12-R12): Updated the `CompileTypesParams` type to use a dictionary (`Dict<string>`) for `exposedModules` instead of an array.
* [`src/plugin.ts`](diffhunk://#diff-57716bc53661ccdb4571d571f1a5493294848965ae6068dbb3d9a1167d2cc1a6R85-R97): Added logic to handle `exposes` as objects with `import` and `name` properties, and updated the `compileTypesAsync` call to use the new `exposedModules` structure. [[1]](diffhunk://#diff-57716bc53661ccdb4571d571f1a5493294848965ae6068dbb3d9a1167d2cc1a6R85-R97) [[2]](diffhunk://#diff-57716bc53661ccdb4571d571f1a5493294848965ae6068dbb3d9a1167d2cc1a6L103-R116)